### PR TITLE
Enable running first activity even if saga aborted

### DIFF
--- a/Orleans.Sagas/SagaGrain.cs
+++ b/Orleans.Sagas/SagaGrain.cs
@@ -17,6 +17,7 @@ namespace Orleans.Sagas
         private readonly IServiceProvider serviceProvider;
         private readonly ILogger<SagaGrain> logger;
         private bool isActive;
+        private IGrainReminder grainReminder;
 
         public SagaGrain(IGrainActivationContext grainContext, IServiceProvider serviceProvider, ILogger<SagaGrain> logger)
         {
@@ -89,48 +90,72 @@ namespace Orleans.Sagas
             return GrainFactory.GetGrain<ISagaCancellationGrain>(this.GetPrimaryKey());
         }
 
-        private async Task<IGrainReminder> RegisterReminderAsync()
+        private async Task RegisterReminderAsync()
         {
             var reminderTime = TimeSpan.FromMinutes(1);
-            return await RegisterOrUpdateReminder(ReminderName, reminderTime, reminderTime);
+            grainReminder = await RegisterOrUpdateReminder(ReminderName, reminderTime, reminderTime);
+        }
+
+        private async Task UnRegisterReminderAsync()
+        {
+            if (grainReminder == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await UnregisterReminder(grainReminder);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(1, "Failed to unregister the reminder", ex);
+            }
         }
 
         private async Task ResumeNoWaitAsync()
         {
             isActive = true;
 
-            await CheckForAbortAsync();
-
-            while (State.Status == SagaStatus.Executing ||
-                   State.Status == SagaStatus.Compensating)
+            try
             {
+                if (State.NumCompletedActivities > 0)
+                {
+                    await CheckForAbortAsync();
+                }
+
+                while (State.Status == SagaStatus.Executing ||
+                       State.Status == SagaStatus.Compensating)
+                {
+                    switch (State.Status)
+                    {
+                        case SagaStatus.Executing:
+                            await ResumeExecuting();
+                            break;
+                        case SagaStatus.Compensating:
+                            await ResumeCompensating();
+                            break;
+                    }
+                }
+
                 switch (State.Status)
                 {
-                    case SagaStatus.Executing:
-                        await ResumeExecuting();
+                    case SagaStatus.NotStarted:
+                        ResumeNotStarted();
                         break;
-                    case SagaStatus.Compensating:
-                        await ResumeCompensating();
+                    case SagaStatus.Executed:
+                    case SagaStatus.Compensated:
+                    case SagaStatus.Aborted:
+                        ResumeCompleted();
                         break;
                 }
-            }
 
-            switch (State.Status)
+                await UnregisterReminder(grainReminder);
+            }
+            finally
             {
-                case SagaStatus.NotStarted:
-                    ResumeNotStarted();
-                    break;
-                case SagaStatus.Executed:
-                case SagaStatus.Compensated:
-                case SagaStatus.Aborted:
-                    ResumeCompleted();
-                    break;
+                isActive = false;
             }
-
-            var reminder = await RegisterReminderAsync();
-            await UnregisterReminder(reminder);
-
-            isActive = false;
         }
 
         private void ResumeNotStarted()
@@ -147,11 +172,6 @@ namespace Orleans.Sagas
         {
             while (State.NumCompletedActivities < State.Activities.Count)
             {
-                if (await CheckForAbortAsync())
-                {
-                    return;
-                }
-
                 var definition = State.Activities[State.NumCompletedActivities];
                 var currentActivity = GetActivity(definition);
 
@@ -171,6 +191,12 @@ namespace Orleans.Sagas
                     State.CompensationIndex = State.NumCompletedActivities;
                     State.Status = SagaStatus.Compensating;
                     await WriteStateAsync();
+                    return;
+                }
+
+                // To ensure running first activity 
+                if (await CheckForAbortAsync())
+                {
                     return;
                 }
             }
@@ -239,7 +265,7 @@ namespace Orleans.Sagas
             {
                 State.Properties.Add(property.Key, property.Value);
             }
-            
+
         }
 
         private ActivityContext CreateActivityRuntimeContext(ActivityDefinition definition)


### PR DESCRIPTION
This PR allows running first activity even if sage been aborted, by doing that we ensure that the consumers of the package will have a way to track over their running sagas.