### PR TITLE
upgrade Orleans version to GA 3.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefaultTargetFrameworkVersion>netcoreapp2.1</DefaultTargetFrameworkVersion>
+    <OrleansSagasVersion>0.0.32-pre</OrleansSagasVersion>
+    <OrleansVersion>3.3.0</OrleansVersion>
+  </PropertyGroup>
+
 </Project>

--- a/Orleans.Sagas.Samples.Activities/Orleans.Sagas.Samples.Activities.csproj
+++ b/Orleans.Sagas.Samples.Activities/Orleans.Sagas.Samples.Activities.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>$(DefaultTargetFrameworkVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Orleans.Sagas.Samples/Orleans.Sagas.Samples.csproj
+++ b/Orleans.Sagas.Samples/Orleans.Sagas.Samples.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.2.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="$(OrleansVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="$(OrleansVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 

--- a/Orleans.Sagas/Orleans.Sagas.csproj
+++ b/Orleans.Sagas/Orleans.Sagas.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.0.31-pre</Version>
+    <TargetFramework>$(DefaultTargetFrameworkVersion)</TargetFramework>
+    <Version>$(OrleansSagasVersion)</Version>
     <Description>A distributed saga implementation for Orleans</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="$(OrleansVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgrade to the latest Orleans GA 3.3.0
- Refactor: move common versions to the `Directory.Build` and reuse