### PR TITLE
Remove predefined placement annotation to allow customization

### DIFF
--- a/Orleans.Sagas/SagaCancellationGrain.cs
+++ b/Orleans.Sagas/SagaCancellationGrain.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 namespace Orleans.Sagas
 {
+    [PreferLocalPlacement]
     public class SagaCancellationGrain : Grain<SagaCancellationGrainState>, ISagaCancellationGrain
     {
         public async Task RequestAbort()

--- a/Orleans.Sagas/SagaCancellationGrain.cs
+++ b/Orleans.Sagas/SagaCancellationGrain.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 
 namespace Orleans.Sagas
 {
-    [PreferLocalPlacement]
     public class SagaCancellationGrain : Grain<SagaCancellationGrainState>, ISagaCancellationGrain
     {
         public async Task RequestAbort()

--- a/Orleans.Sagas/SagaGrain.cs
+++ b/Orleans.Sagas/SagaGrain.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace Orleans.Sagas
 {
-    [PreferLocalPlacement]
     public sealed class SagaGrain : Grain<SagaState>, ISagaGrain
     {
         private static readonly string ReminderName = nameof(SagaGrain);


### PR DESCRIPTION
Reason: consumers need to be able to specify workflow grain placement in the cluster