### PR TITLE
Support re-run activity that using sagaPropertBag to pass information

### DIFF
--- a/Orleans.Sagas/Orleans.Sagas.csproj
+++ b/Orleans.Sagas/Orleans.Sagas.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFrameworkVersion)</TargetFramework>
-    <Version>0.0.35-pre</Version>
+    <Version>0.0.36-pre</Version>
     <Description>A distributed saga implementation for Orleans</Description>
   </PropertyGroup>
 

--- a/Orleans.Sagas/SagaPropertyBag.cs
+++ b/Orleans.Sagas/SagaPropertyBag.cs
@@ -23,11 +23,11 @@ namespace Orleans.Sagas
         {
             if (typeof(T) == typeof(string))
             {
-                ContextProperties.Add(key, (string)(dynamic)value);
+                ContextProperties[key] = (string)(dynamic)value;
                 return;
             }
 
-            ContextProperties.Add(key, JsonConvert.SerializeObject(value));
+            ContextProperties[key] = JsonConvert.SerializeObject(value);
         }
 
         public T Get<T>(string key)


### PR DESCRIPTION
We're using SagaPropertBag to pass parameters between different activities, and we have a re-try mechanism to re-run failing activities, but in case we run the same activity that already added a key to the bag, we will get an exception that key already exists.

This fix should fix the issue above. 